### PR TITLE
check_compatibility method always returns False

### DIFF
--- a/confluent/schemaregistry/client/CachedSchemaRegistryClient.py
+++ b/confluent/schemaregistry/client/CachedSchemaRegistryClient.py
@@ -207,7 +207,7 @@ class CachedSchemaRegistryClient(object):
         body = { 'schema' : json.dumps(avro_schema.to_json()) }
         try:
             result,meta,code = self._send_request(url, method='POST', body=body)
-            return result.get('is_compatible') == "true"
+            return result.get('is_compatible')
         except:
             return False
 


### PR DESCRIPTION
Basically, the `check_compatibility` method was returning False 100% of the time because it compared boolean True or False to the string 'true'...
