### PR TITLE
Optionaly return schema id together with decoded message

### DIFF
--- a/confluent/schemaregistry/serializers/MessageSerializer.py
+++ b/confluent/schemaregistry/serializers/MessageSerializer.py
@@ -166,7 +166,7 @@ class MessageSerializer(object):
         self.id_to_decoder_func[schema_id] = decoder
         return self.id_to_decoder_func[schema_id]
 
-    def decode_message(self, message):
+    def decode_message(self, message, with_schema_id=False):
         """
         Decode a message from kafka that has been encoded for use with
         the schema registry.
@@ -179,4 +179,8 @@ class MessageSerializer(object):
             if magic != MAGIC_BYTE:
                 raise SerializerError("message does not start with magic byte")
             decoder_func = self._get_decoder_func(schema_id, payload)
-            return decoder_func(payload)
+            decoded = decoder_func(payload)
+            if with_schema_id:
+                return (decoded, schema_id)
+            else:
+                return decoded

--- a/confluent/schemaregistry/serializers/MessageSerializer.py
+++ b/confluent/schemaregistry/serializers/MessageSerializer.py
@@ -55,7 +55,7 @@ class MessageSerializer(object):
         try:
             schema_id = self.registry_client.register(subject, schema)
         except:
-            message_none = "Exception, schema_id will be set to None! %s" % (schema_id)
+            message_none = "Exception, schema_id will be set to None!"
             raise SerializerError(message_none)
             schema_id = None
 

--- a/confluent/schemaregistry/serializers/MessageSerializer.py
+++ b/confluent/schemaregistry/serializers/MessageSerializer.py
@@ -55,6 +55,8 @@ class MessageSerializer(object):
         try:
             schema_id = self.registry_client.register(subject, schema)
         except:
+            message_none = "Exception, schema_id will be set to None! %s" % (schema_id)
+            raise SerializerError(message_none)
             schema_id = None
 
         if not schema_id:


### PR DESCRIPTION
Useful for changing the record and encoding back using the same schema.
