### PR TITLE
add missing import

### DIFF
--- a/confluent/schemaregistry/serializers/MessageSerializer.py
+++ b/confluent/schemaregistry/serializers/MessageSerializer.py
@@ -4,6 +4,7 @@ import json
 import struct
 import sys
 
+from confluent.schemaregistry.client import ClientError
 from . import SerializerError
 
 MAGIC_BYTE = 0


### PR DESCRIPTION
The ClientError exception was missing from the imports in MessageSerializer. Judging from the comments in the implementation of the `client.get_by_id` method I'm guessing the test cases missed it because the MockSchemaRegistryClient does not have a stub that would throw the exception because it's not expected happen. It does happen in certain circumstances though and that's how I discovered the missing import.
